### PR TITLE
Add dark mode toggle with sun/moon icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,18 @@
     <!-- nav bar start -->
     <nav class="navbar sticky-top text-dark mb-4 ourNav" id="indexNav">
     </nav>
+    
+    <!-- Dark Mode Toggle -->
+   <div class="dark-toggle">
+  <input type="checkbox" id="darkModeToggle">
+  <label for="darkModeToggle" class="toggle-icon">
+    <span class="icon sun"></span>
+    <span class="icon moon"></span>
+  </label>
+  </div>
+
+
+
     <!-- nav bar start -->
 
     <!-- feature list start -->
@@ -779,6 +791,9 @@
     <script src="static/js/common.js"></script>
     <script src="static/js/script.js"></script>
     <script src="static/bootstrap-5.3.3-dist/js/bootstrap.bundle.min.js"></script>
+
+   
+
 </body>
 
 </html>

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -729,24 +729,237 @@ a {
     background: #ffffff7a !important;
 }
 
-/*
-* hover/slow bounce animation
-*/
-@keyframes ghost-hover {
-    0% {
-        transform: translate(0%, -15%);
-        color: rgba(189, 255, 189, 0.761);
-    }
+/* =====================================================
+   Dark Mode Styles
+===================================================== */
 
-    50% {
-        transform: translate(0%, 0%);
-        color: rgba(189, 255, 189, 0.761);
-    }
-
-    100% {
-        transform: translate(0%, 15%);
-    }
+/* -------------------------------
+   Base
+-------------------------------- */
+body.dark-mode {
+  background-color: #020617 !important;
+  color: #e5e7eb !important;
 }
 
+/* -------------------------------
+   Header / Navbar
+-------------------------------- */
+body.dark-mode header,
+body.dark-mode .navbar {
+  background-color: #020617 !important;
+}
 
-/* For back animation end */
+body.dark-mode .navbar *,
+body.dark-mode header * {
+  color: #f9fafb !important;
+}
+
+/* -------------------------------
+   Icons
+-------------------------------- */
+body.dark-mode img,
+body.dark-mode svg,
+body.dark-mode i {
+  filter: brightness(0) invert(1);
+}
+
+/* -------------------------------
+   Cards / Containers
+-------------------------------- */
+body.dark-mode .card,
+body.dark-mode .container,
+body.dark-mode .panel,
+body.dark-mode .content-box {
+  background-color: #020617 !important;
+  color: #e5e7eb !important;
+  border: 1px solid #334155;
+}
+
+/* -------------------------------
+   Inputs & Selects
+-------------------------------- */
+body.dark-mode input,
+body.dark-mode textarea,
+body.dark-mode select {
+  background-color: #020617 !important;
+  color: #f9fafb !important;
+  border: 1px solid #334155;
+}
+
+body.dark-mode input::placeholder,
+body.dark-mode textarea::placeholder {
+  color: #9ca3af;
+}
+
+/* -------------------------------
+   Buttons
+-------------------------------- */
+body.dark-mode button {
+  background-color: #1e293b;
+  color: #e5e7eb;
+}
+
+/* -------------------------------
+   Links
+-------------------------------- */
+body.dark-mode a {
+  color: #60a5fa;
+}
+
+body.dark-mode a:hover {
+  color: #93c5fd;
+}
+
+/* =====================================================
+   Error / Info Modal
+===================================================== */
+
+body.dark-mode .modal-content {
+  background-color: #fee2e2 !important;
+  border: 1px solid #fca5a5;
+  color: #020617 !important;
+  opacity: 1 !important;
+}
+
+body.dark-mode .modal-content * {
+  color: #020617 !important;
+  filter: none !important;
+}
+
+body.dark-mode .modal-content a {
+  color: #2563eb !important;
+  font-weight: 500;
+}
+
+/* =====================================================
+   Download Button (Navbar)
+===================================================== */
+
+body.dark-mode .navbar .download-btn,
+body.dark-mode .navbar .btn-download,
+body.dark-mode .navbar .badge {
+  background-color: #ffffff !important;
+  color: #000000 !important;
+  border: 1px solid #e5e7eb !important;
+  filter: none !important;
+}
+
+body.dark-mode .navbar .download-btn *,
+body.dark-mode .navbar .btn-download *,
+body.dark-mode .navbar .badge * {
+  color: #000000 !important;
+  filter: none !important;
+}
+
+body.dark-mode .navbar .download-btn i,
+body.dark-mode .navbar .btn-download i,
+body.dark-mode .navbar .badge i,
+body.dark-mode .navbar .download-btn svg,
+body.dark-mode .navbar .btn-download svg,
+body.dark-mode .navbar .badge svg {
+  filter: none !important;
+}
+
+body.dark-mode .navbar .download-btn:hover,
+body.dark-mode .navbar .btn-download:hover,
+body.dark-mode .navbar .badge:hover {
+  background-color: #ffffff !important;
+  color: #000000 !important;
+}
+
+/* =====================================================
+   Dark Mode Toggle (Sun / Moon)
+===================================================== */
+
+.dark-toggle {
+  position: fixed;
+  top: 70px;
+  right: 16px;
+  z-index: 9999;
+}
+
+.dark-toggle input {
+  display: none;
+}
+
+.toggle-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: #e5e7eb;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+}
+
+/* Icon base */
+.toggle-icon .icon {
+  width: 24px;
+  height: 24px;
+  background-size: 24px 24px;
+  background-repeat: no-repeat;
+}
+
+/* Sun icon */
+.toggle-icon .sun {
+  background-image: url("data:image/svg+xml;utf8,\
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2'>\
+<circle cx='12' cy='12' r='4'/>\
+<line x1='12' y1='1' x2='12' y2='4'/>\
+<line x1='12' y1='20' x2='12' y2='23'/>\
+<line x1='4.22' y1='4.22' x2='6.34' y2='6.34'/>\
+<line x1='17.66' y1='17.66' x2='19.78' y2='19.78'/>\
+<line x1='1' y1='12' x2='4' y2='12'/>\
+<line x1='20' y1='12' x2='23' y2='12'/>\
+</svg>");
+}
+
+/* Moon icon */
+.toggle-icon .moon {
+  display: none;
+  background-image: url("data:image/svg+xml;utf8,\
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2'>\
+<path d='M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z'/>\
+</svg>");
+}
+
+/* Dark mode state */
+body.dark-mode .toggle-icon {
+  background: #020617;
+}
+
+body.dark-mode .sun {
+  display: none;
+}
+
+body.dark-mode .moon {
+  display: block;
+}
+
+/* -------------------------------
+   Navbar separation in dark mode
+-------------------------------- */
+body.dark-mode .ourNav,
+body.dark-mode .navbar {
+  background: linear-gradient(180deg, #020617 0%, #020617 100%) !important;
+  border-bottom: 1px solid #1e293b !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+}
+
+/* -------------------------------
+   Toggle contrast in dark mode
+-------------------------------- */
+body.dark-mode .dark-toggle .toggle-icon {
+  background: #0f172a;
+  border: 1px solid #334155;
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.6),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+body.dark-mode .dark-toggle .moon {
+  stroke: #f9fafb;
+  color: #f9fafb;
+}

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -867,5 +867,37 @@ function setModalSettingsList() {
             showElement("chatContainer", false);
             console.error('There was a problem with the fetch operation:', error);
         }));
+    }
 
-}
+        document.addEventListener("DOMContentLoaded", () => {
+  const toggle = document.getElementById("darkModeToggle");
+  if (!toggle) return;
+
+  const body = document.body;
+
+
+});
+document.addEventListener("DOMContentLoaded", () => {
+  const body = document.body;
+  const toggle = document.getElementById("darkModeToggle");
+
+  if (!toggle) return;
+
+  // Load saved preference
+  if (localStorage.getItem("darkMode") === "enabled") {
+    body.classList.add("dark-mode");
+    toggle.checked = true;
+  }
+
+  toggle.addEventListener("change", () => {
+    body.classList.toggle("dark-mode", toggle.checked);
+    localStorage.setItem(
+      "darkMode",
+      toggle.checked ? "enabled" : "disabled"
+    );
+  });
+});
+
+
+
+


### PR DESCRIPTION
This PR adds a dark mode option to the extension with
a sun/moon toggle and persists user preference.

I picked this up from the existing "Give Dark Theme For Extension" issue and
worked on it directly as it was marked as a good first issue. Please let me
know if you’d like any changes, refinements, or adjustments to better match
the project’s direction.
<img width="1911" height="938" alt="Screenshot 2025-12-16 130226" src="https://github.com/user-attachments/assets/45ddda0c-d640-4450-b9e2-934370108b53" />
<img width="1908" height="923" alt="Screenshot 2025-12-16 130240" src="https://github.com/user-attachments/assets/de3d3202-038c-48e4-873f-5824ca7533cc" />


Fixes #1

